### PR TITLE
feat: Create clean blog with macOS-style code blocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "github-pages", group: :jekyll_plugins

--- a/_posts/2025-08-12-sample-post.md
+++ b/_posts/2025-08-12-sample-post.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title: "Sample Post: Styling Code with Jekyll"
+date: 2025-08-12
+---
+
+This post demonstrates the custom styling for code blocks. The goal is to emulate the look of a macOS window, complete with "traffic light" buttons.
+
+Here is an example of a Python code block:
+
+```python
+import os
+
+def list_files(startpath):
+    for root, dirs, files in os.walk(startpath):
+        level = root.replace(startpath, '').count(os.sep)
+        indent = ' ' * 4 * (level)
+        print('{}{}/'.format(indent, os.path.basename(root)))
+        subindent = ' ' * 4 * (level + 1)
+        for f in files:
+            print('{}{}'.format(subindent, f))
+```
+
+And here is a shell script example:
+
+```bash
+#!/bin/bash
+# A simple script to greet the user
+echo "Hello, $(whoami)!"
+```
+
+The styling is handled entirely by CSS, making it easy to customize. You can find the relevant styles in `assets/style.css`.

--- a/assets/style.css
+++ b/assets/style.css
@@ -29,6 +29,7 @@ a:hover {
 /* GitHub/Mac-style code blocks */
 pre {
   background: #f6f8fa;
+  border: 1px solid #d1d5da;
   border-radius: 6px;
   overflow-x: auto;
   padding: 0;
@@ -40,7 +41,7 @@ pre::before {
   content: '';
   display: block;
   height: 28px;
-  background: #f6f8fa;
+  background: #e8e8e8;
   border-bottom: 1px solid #d1d5da;
   border-top-left-radius: 6px;
   border-top-right-radius: 6px;
@@ -60,7 +61,9 @@ pre::after {
 
 pre code {
   display: block;
-  padding: 1em;
+  padding: 1.5em 1em;
   font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
   font-size: 14px;
+  line-height: 1.5;
+  color: #24292e;
 }

--- a/index.md
+++ b/index.md
@@ -3,19 +3,16 @@ layout: default
 title: Home
 ---
 
-# Welcome to My Blog
+## Blog Posts
 
-This is a clean Jekyll blog inspired by Substack's typography and GitHub's code styling.
-
-```python
-def hello():
-    print("Hello, world!")
-```
-
----
-
-### 6. `Gemfile`
-```ruby
-source "https://rubygems.org"
-gem "github-pages", group: :jekyll_plugins
-```
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <h3>
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      </h3>
+      <p><small>{{ post.date | date: "%B %d, %Y" }}</small></p>
+      <p>{{ post.excerpt }}</p>
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
This commit finalizes the setup for a clean, minimalistic Jekyll blog designed for GitHub Pages.

Key features include:
- A `Gemfile` configured for GitHub Pages.
- A dynamic `index.md` that lists all blog posts.
- A sample post to demonstrate the styling.
- Custom CSS to style code blocks like macOS windows, with a title bar and "traffic light" buttons.
- Refined typography and spacing for improved readability.