### PR TITLE
Configure Jekyll for GitHub Pages deployment.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@
 title:               'Alessandro Carraro'
 #tagline:             'A blog about my thoughts and experiences.'
 description:         'Welcome to my blog. Here I will share my projects'
-url:                 ''
-baseurl:             ''
+url:                 'https://alecarraro.github.io'
+baseurl:             '/alecarraro-blog'
 paginate:            5
 permalink:           pretty
 


### PR DESCRIPTION
This commit updates the `_config.yml` file to correctly configure the Jekyll site for deployment on GitHub Pages.

The `url` and `baseurl` fields have been set to match the user's GitHub username (`alecarraro`) and the new repository name (`alecarraro-blog`). This ensures that all links and assets will resolve correctly when the site is published on GitHub Pages.

Local build verification was not possible due to the absence of a Ruby development environment in the sandbox.